### PR TITLE
[ISV-4528] Automatically merge approved PRs

### DIFF
--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Get base ref
         id: base_ref
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           PR_URL="$(jq -r '.issue.pull_request.html_url' "${GITHUB_EVENT_PATH}")"
           REF="$(gh pr view "${PR_URL}" --json baseRefName --jq .baseRefName)"

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -46,16 +46,17 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/approve') && !contains(github.event.issue.labels.*.name, 'approved') }}
     runs-on: [ubuntu-latest]
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Get base ref
+        id: base_ref
         run: |
-          echo "$GITHUB_CONTEXT"
+          PR_URL="$(jq -r '.issue.pull_request.html_url' "${GITHUB_EVENT_PATH}")"
+          REF="$(gh pr view "${PR_URL}" --json baseRefName --jq .baseRefName)"
+          echo "BASE_REF=${REF}" >>"${GITHUB_OUTPUT}"
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ steps.base_ref.outputs.BASE_REF }}
           fetch-depth: 1
           sparse-checkout: |
             operators

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -1,4 +1,4 @@
-name: Controll PR labels using action comments
+name: Handle PR comments
 
 on:
   issue_comment:
@@ -6,9 +6,9 @@ on:
   workflow_call:
 
 jobs:
-  skip-test-labeler:
+  test-skip:
     # This job adds skip test labels to PRs for allowed tests
-    if: ${{ github.event.issue.pull_request }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/test skip') }}
     runs-on: [ubuntu-latest]
     steps:
       - name: Skip check_pruned_graph test
@@ -17,8 +17,8 @@ jobs:
         with:
           labels: tests/skips/check_pruned_graph
 
-  trigger-pipeline:
-    if: ${{ github.event.issue.pull_request }}
+  pipeline-restart:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/pipeline restart') }}
     runs-on: [ubuntu-latest]
     steps:
       - name: Trigger isv hosted pipeline
@@ -68,10 +68,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -x
-
           authorization() {
             echo "AUTHORIZED=$1" >>"${GITHUB_OUTPUT}"
+            echo "Authorized: $1"
             exit 0
           }
 

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -43,7 +43,7 @@ jobs:
           labels: pipeline/trigger-release
 
   approve:
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/approve') && !contains(github.event.issue.labels.*.name, 'approved') }}
+    if: ${{ github.event.issue.pull_request && github.event.repository.name.startsWith("community-") && github.event.issue.state == 'open' && startsWith(github.event.comment.body, '/approve') }}
     runs-on: [ubuntu-latest]
     steps:
       - name: Get base ref
@@ -89,10 +89,15 @@ jobs:
           done
           authorization true
 
-      - name: Apply label
+      - name: Apply approved label
         uses: actions-ecosystem/action-add-labels@v1
-        if: ${{ steps.authorized.outputs.AUTHORIZED == 'true' }}
+        if: ${{ steps.authorized.outputs.AUTHORIZED == 'true'  && !contains(github.event.issue.labels.*.name, 'approved') }}
         with:
-          labels: |
-            approved
-            pipeline/trigger-hosted
+          labels: approved
+
+      - name: Apply trigger label
+        uses: actions-ecosystem/action-add-labels@v1
+        # Only trigger a pipeline run if the pipeline is not already running
+        if: ${{ steps.authorized.outputs.AUTHORIZED == 'true'  && !contains(github.event.issue.labels.*.name, 'operator-hosted-pipeline/started') }}
+        with:
+          labels: pipeline/trigger-hosted

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -59,6 +59,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -x
+
           authorization() {
             echo "AUTHORIZED=$1" >>"${GITHUB_OUTPUT}"
             exit 0
@@ -79,10 +81,8 @@ jobs:
           done
           authorization true
 
-      - name: Apply labels
+      - name: Apply label
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.authorized.outputs.AUTHORIZED == 'true' }}
         with:
-          labels: |
-            approved
-            pipeline/trigger-hosted
+          labels: approved

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -43,7 +43,7 @@ jobs:
           labels: pipeline/trigger-release
 
   approve:
-    if: ${{ github.event.issue.pull_request && github.event.repository.name.startsWith("community-") && github.event.issue.state == 'open' && startsWith(github.event.comment.body, '/approve') }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.repository.name, 'community-') && github.event.issue.state == 'open' && startsWith(github.event.comment.body, '/approve') }}
     runs-on: [ubuntu-latest]
     steps:
       - name: Get base ref

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -5,40 +5,84 @@ on:
     types: [created, edited]
   workflow_call:
 
-
 jobs:
   skip-test-labeler:
     # This job adds skip test labels to PRs for allowed tests
     if: ${{ github.event.issue.pull_request }}
     runs-on: [ubuntu-latest]
     steps:
-    - name: Skip check_pruned_graph test
-      uses: actions-ecosystem/action-add-labels@v1
-      if: ${{ startsWith(github.event.comment.body, '/test skip check_pruned_graph') }}
-      with:
-        labels: tests/skips/check_pruned_graph
+      - name: Skip check_pruned_graph test
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.comment.body, '/test skip check_pruned_graph') }}
+        with:
+          labels: tests/skips/check_pruned_graph
 
   trigger-pipeline:
     if: ${{ github.event.issue.pull_request }}
     runs-on: [ubuntu-latest]
     steps:
-    - name: Trigger isv hosted pipeline
-      if: ${{ startsWith(github.event.comment.body, '/pipeline restart operator-hosted-pipeline')  && contains( github.event.issue.labels.*.name, 'operator-hosted-pipeline/failed') }}
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: pipeline/trigger-hosted
-    - name: Trigger isv release pipeline
-      if: ${{ startsWith(github.event.comment.body, '/pipeline restart operator-release-pipeline')  && contains( github.event.issue.labels.*.name, 'operator-release-pipeline/failed') }}
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: pipeline/trigger-release
-    - name: Trigger community hosted pipeline
-      if: ${{ startsWith(github.event.comment.body, '/pipeline restart community-hosted-pipeline')  && contains( github.event.issue.labels.*.name, 'community-hosted-pipeline/failed') }}
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: pipeline/trigger-hosted
-    - name: Trigger community release pipeline
-      if: ${{ startsWith(github.event.comment.body, '/pipeline restart community-release-pipeline')  && contains( github.event.issue.labels.*.name, 'community-release-pipeline/failed') }}
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: pipeline/trigger-release
+      - name: Trigger isv hosted pipeline
+        if: ${{ startsWith(github.event.comment.body, '/pipeline restart operator-hosted-pipeline') && contains(github.event.issue.labels.*.name, 'operator-hosted-pipeline/failed') }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: pipeline/trigger-hosted
+      - name: Trigger isv release pipeline
+        if: ${{ startsWith(github.event.comment.body, '/pipeline restart operator-release-pipeline') && contains(github.event.issue.labels.*.name, 'operator-release-pipeline/failed') }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: pipeline/trigger-release
+      - name: Trigger community hosted pipeline
+        if: ${{ startsWith(github.event.comment.body, '/pipeline restart community-hosted-pipeline') && contains(github.event.issue.labels.*.name, 'community-hosted-pipeline/failed') }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: pipeline/trigger-hosted
+      - name: Trigger community release pipeline
+        if: ${{ startsWith(github.event.comment.body, '/pipeline restart community-release-pipeline') && contains(github.event.issue.labels.*.name, 'community-release-pipeline/failed') }}
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: pipeline/trigger-release
+
+  approve:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/approve') && !contains(github.event.issue.labels.*.name, 'approved') }}
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.issue.pull_request.base.ref }}
+          fetch-depth: 1
+          sparse-checkout: |
+            operators
+
+      - name: Check permission
+        id: authorized
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          authorization() {
+            echo "AUTHORIZED=$1" >>"${GITHUB_OUTPUT}"
+            exit 0
+          }
+
+          PR_URL="$(jq -r '.issue.pull_request.html_url' "${GITHUB_EVENT_PATH}")"
+          COMMENT_AUTHOR="$(jq -r '.comment.user.login' "${GITHUB_EVENT_PATH}")"
+          mapfile -t AFFECTED_OPERATORS < <(
+            gh pr diff "${PR_URL}" --name-only |
+            awk -F/ '$1=="operators"&&NF>2{operators[$2]=1} $1=="catalogs"&&NF>3{operators[$3]=1} END{for (o in operators) print o}'
+          )
+          AFFECTED_OPERATORS_COUNT="${#AFFECTED_OPERATORS[*]}"
+          [ "${AFFECTED_OPERATORS_COUNT}" -gt 0 ] || authorization false
+          for operator in "${AFFECTED_OPERATORS[@]}"; do
+            ci_yaml="operators/${operator}/ci.yaml"
+            [ -f "${ci_yaml}" ] || authorization false
+            yq -r '.reviewers[]' "${ci_yaml}" | grep -Fqx "${COMMENT_AUTHOR}" || authorization false
+          done
+          authorization true
+
+      - name: Apply labels
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.authorized.outputs.AUTHORIZED == 'true' }}
+        with:
+          labels: |
+            approved
+            pipeline/trigger-hosted

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -46,10 +46,16 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/approve') && !contains(github.event.issue.labels.*.name, 'approved') }}
     runs-on: [ubuntu-latest]
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.issue.pull_request.base.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 1
           sparse-checkout: |
             operators

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -93,4 +93,6 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.authorized.outputs.AUTHORIZED == 'true' }}
         with:
-          labels: approved
+          labels: |
+            approved
+            pipeline/trigger-hosted

--- a/.github/workflows/label-command.yml
+++ b/.github/workflows/label-command.yml
@@ -26,18 +26,9 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: pipeline/trigger-hosted
+
       - name: Trigger isv release pipeline
         if: ${{ startsWith(github.event.comment.body, '/pipeline restart operator-release-pipeline') && contains(github.event.issue.labels.*.name, 'operator-release-pipeline/failed') }}
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: pipeline/trigger-release
-      - name: Trigger community hosted pipeline
-        if: ${{ startsWith(github.event.comment.body, '/pipeline restart community-hosted-pipeline') && contains(github.event.issue.labels.*.name, 'community-hosted-pipeline/failed') }}
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: pipeline/trigger-hosted
-      - name: Trigger community release pipeline
-        if: ${{ startsWith(github.event.comment.body, '/pipeline restart community-release-pipeline') && contains(github.event.issue.labels.*.name, 'community-release-pipeline/failed') }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: pipeline/trigger-release


### PR DESCRIPTION
- Added handling of `/approve` commands for the community pipeline
- Removed handling of restart commands for obsolete community pipeline specific labels
- Slightly improved performance by skipping entire jobs (as opposed to individual steps) when comments do not match the expected prefix